### PR TITLE
Add option to toggle code folding

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -90,9 +90,14 @@
         <lang.commenter
                 implementationClass="mobi.hsz.idea.latex.lang.LatexCommenter"
                 language="LaTeX"/>
+
+        <codeFoldingOptionsProvider instance="mobi.hsz.idea.latex.folding.LatexFoldingOptionsProvider" />
+        <applicationService serviceInterface="mobi.hsz.idea.latex.folding.LatexFoldingSettings"
+                            serviceImplementation="mobi.hsz.idea.latex.folding.LatexFoldingSettings" />
         <lang.foldingBuilder
                 implementationClass="mobi.hsz.idea.latex.folding.LatexFoldingBuilder"
                 language="LaTeX"/>
+
         <lang.parserDefinition
                 implementationClass="mobi.hsz.idea.latex.lang.LatexParserDefinition"
                 language="LaTeX"/>

--- a/resources/messages/LatexBundle.properties
+++ b/resources/messages/LatexBundle.properties
@@ -12,6 +12,7 @@ editor.table=Insert table
 editor.table.dialog.title=LaTeX - Insert Table
 editor.underline=Underline
 colorSettings.displayName=LaTeX
+foldingSettings.add.folding.for.all.blocks=Enable Folding (LaTeX)
 highlighter.instruction=Instruction
 highlighter.argument=Argument
 highlighter.bracket=Brackets

--- a/src/mobi/hsz/idea/latex/folding/LatexFoldingBuilder.java
+++ b/src/mobi/hsz/idea/latex/folding/LatexFoldingBuilder.java
@@ -48,6 +48,8 @@ import java.util.List;
  */
 public class LatexFoldingBuilder implements FoldingBuilder {
 
+    private final LatexFoldingSettings foldingSettings = LatexFoldingSettings.getInstance();
+
     /** Descriptors collection. */
     private final List<FoldingDescriptor> descriptors = new ArrayList<FoldingDescriptor>();
 
@@ -84,8 +86,9 @@ public class LatexFoldingBuilder implements FoldingBuilder {
     @NotNull
     public FoldingDescriptor[] buildFoldRegions(@NotNull final ASTNode node, @NotNull final Document document) {
         descriptors.clear();
-        node.getPsi().acceptChildren(visitor);
-
+        if(foldingSettings.isFoldingForAllBlocks()){
+          node.getPsi().acceptChildren(visitor);
+        }
         return descriptors.toArray(new FoldingDescriptor[descriptors.size()]);
     }
 

--- a/src/mobi/hsz/idea/latex/folding/LatexFoldingOptionsProvider.java
+++ b/src/mobi/hsz/idea/latex/folding/LatexFoldingOptionsProvider.java
@@ -1,0 +1,14 @@
+package mobi.hsz.idea.latex.folding;
+
+import com.intellij.application.options.editor.CodeFoldingOptionsProvider;
+import com.intellij.openapi.options.BeanConfigurable;
+import mobi.hsz.idea.latex.LatexBundle;
+import mobi.hsz.idea.latex.folding.LatexFoldingSettings;
+
+public class LatexFoldingOptionsProvider extends BeanConfigurable<LatexFoldingSettings> implements CodeFoldingOptionsProvider {
+
+    public LatexFoldingOptionsProvider() {
+        super(LatexFoldingSettings.getInstance());
+        checkBox("FoldingForAllBlocks", LatexBundle.message("foldingSettings.add.folding.for.all.blocks"));
+    }
+}

--- a/src/mobi/hsz/idea/latex/folding/LatexFoldingSettings.java
+++ b/src/mobi/hsz/idea/latex/folding/LatexFoldingSettings.java
@@ -1,0 +1,49 @@
+package mobi.hsz.idea.latex.folding;
+
+import com.intellij.codeInsight.folding.CodeFoldingSettings;
+import com.intellij.openapi.application.PathManager;
+import com.intellij.openapi.components.*;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+
+@State(
+        name = "LatexFoldingSettings",
+        storages = {@Storage("latex_folding_settings.xml")}
+)
+public class LatexFoldingSettings implements PersistentStateComponent<LatexFoldingSettings>, ExportableComponent {
+    private boolean ADD_FOLDING_FOR_ALL_BLOCKS = false;
+
+    public static LatexFoldingSettings getInstance() {
+        return ServiceManager.getService(LatexFoldingSettings.class);
+    }
+
+    public LatexFoldingSettings getState() {
+        return this;
+    }
+
+    public void loadState(LatexFoldingSettings latexFoldingSettings) {
+        XmlSerializerUtil.copyBean(latexFoldingSettings, this);
+    }
+
+    @NotNull
+    public File[] getExportFiles() {
+        return new File[]{PathManager.getOptionsFile("latex_folding_settings")};
+    }
+
+    @NotNull
+    public String getPresentableName() {
+        return "Latex Folding Settings";
+    }
+
+    public boolean isFoldingForAllBlocks() {
+        return ADD_FOLDING_FOR_ALL_BLOCKS;
+    }
+
+    public boolean getFoldingForAllBlocks() { return ADD_FOLDING_FOR_ALL_BLOCKS; }
+    public void setFoldingForAllBlocks(boolean value) {
+        ADD_FOLDING_FOR_ALL_BLOCKS = value;
+    }
+
+}


### PR DESCRIPTION
Add an option to disable code folding entirely as it is not always desired by all users. This PR is a strawman for suggestions to enable more detailed code folding options. It is likely not ideal and probably doesn't work correctly (in terms of re-enabling and toggling on the fly) -- it works for me but I'm new to IntelliJ extensions, so criticism is more than welcome and probably quite mandatory.